### PR TITLE
Fix for DataLocationProxy returning null

### DIFF
--- a/lib/plugins/sammy.data_location_proxy.js
+++ b/lib/plugins/sammy.data_location_proxy.js
@@ -67,7 +67,7 @@
     },
 
     getLocation: function() {
-      return this.app.$element().data(this.data_name);
+      return this.app.$element().data(this.data_name) || '';
     },
 
     setLocation: function(new_location) {

--- a/test/test_sammy_location_proxy.js
+++ b/test/test_sammy_location_proxy.js
@@ -101,7 +101,13 @@
       equal(this.app._location_proxy.getLocation(), '#/zuh');
       this.app._location_proxy.setLocation('#/boosh');
       equal('#/boosh', this.app._location_proxy.getLocation());
+    })
+    .should('return an empty string when there is no location stored in data', function() {
+      $.removeData($('body')[0], this.app._location_proxy.data_name);
+      equal(null, $('body').data(this.app._location_proxy.data_name));
+      equal('', this.app._location_proxy.getLocation());
     });
+
 
   }
 })(jQuery);


### PR DESCRIPTION
Hi Aaron,
I ran into an issue when using the DataLocationProxy.  The following app would fail with 'path is null' 

var app = $.sammy('div.app',function(a){
  a.setLocationProxy(new Sammy.DataLocationProxy(this));
  a.get('#/',function(){
    this.swap('Hello world')
  })
});
app.run('#/');

This is because the jQuery data method returns null when there is no data set.  The Sammy code expects an empty string to be returned when there is no location set as this is what is returned by the HashChangeProxy.  I've updated the DataLocationProxy to return the same as the HashChangeProxy.

Would this be your preferred way of doing things, or should the sammy code (#823 - #824) check for an empty string and null rather than just an empty string?

Cheers
James
