### PR TITLE
$element accept a jQuery selector

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -364,8 +364,8 @@
     },
 
     // returns a jQuery object of the Applications bound element.
-    $element: function() {
-      return $(this.element_selector);
+    $element: function(selector) {
+      return selector ? $(this.element_selector).find(selector) : $(this.element_selector);
     },
 
     // `use()` is the entry point for including Sammy plugins.
@@ -1660,7 +1660,7 @@
 
     // A shortcut to the app's `$element()`
     $element: function() {
-      return this.app.$element();
+      return this.app.$element(_makeArray(arguments).shift());
     },
 
     // Look up a templating engine within the current app and context.

--- a/test/test_sammy_application.js
+++ b/test/test_sammy_application.js
@@ -1040,7 +1040,19 @@
         equal(this.app.c, 3);
       });
 
-
+      context('Sammy.Application', '$element', {
+        before: function() {
+          this.app = $.sammy(function() {
+            this.element_selector = '#main';
+          });
+        }
+      })
+      .should('accept an element selector', function() {
+        sameHTML(this.app.$element('.inline-template-1'), '<div class="inline-template-1"><div class="name"></div></div>');
+      })
+      .should('return the app element if no selector is given', function() {
+        equal(this.app.$element().attr('id'), 'main');
+      });
     }
   // });
 })(jQuery);


### PR DESCRIPTION
Hey, just a small patch to allow the `app.$element()` method to accept a selector. 

Really just skips the extra call to `.find(...)` from the user perspective.

```
// Before
this.$element().find('#tweets').prepend(tweet);

// After
this.$element('#tweets').prepend(tweet);
```

p.s. Apologies for the incorrect commit message, `$element` got swallowed by the prompt!
