### PR TITLE
_decode should convert '+' url character to space, not leave as '+'

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -12,7 +12,7 @@
       // borrowed from jQuery
       _isFunction = function( obj ) { return Object.prototype.toString.call(obj) === "[object Function]"; },
       _isArray = function( obj ) { return Object.prototype.toString.call(obj) === "[object Array]"; },
-      _decode = decodeURIComponent,
+      _decode = function( str ) { return decodeURIComponent(str.replace(/\+/g, ' ')); },
       _encode = encodeURIComponent,
       _escapeHTML = function(s) {
         return String(s).replace(/&(?!\w+;)/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');


### PR DESCRIPTION
This fixes a bug where if your url contains the + character, indicating whitespace, it will be left as + when run through _decode.

More here: http://stackoverflow.com/questions/901115/get-querystring-values-with-jquery
