### PR TITLE
Adds support for more template caching options

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -1687,7 +1687,7 @@
       if (_isFunction(engine)) { return engine; }
       // lookup engine name by path extension
       engine = (engine || context.app.template_engine).toString();
-      if ((engine_match = engine.match(/\.([^\.]+)$/))) {
+      if ((engine_match = engine.match(/\.([^\.\?\#]+)/))) {
         engine = engine_match[1];
       }
       // set the engine to the default template engine if no match is found


### PR DESCRIPTION
We wanted to implement caching to force ejs templates to be fetched after a deploy. We did this with an md5 checksum of the form "/template.ejs?md5". This conflicted with the engineFor logic, and it was unable to determine the engine ejs. We changed the regex to exclude the query and fragment portions of the uri, allowing support for this kind of caching.
