### PR TITLE
HashLocationProxy does not need to constantly trigger the 'hashchange' event when there is no hash.

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -271,7 +271,7 @@
         if (!every) { every = 10; }
         var hashCheck = function() {
           var current_location = proxy.getLocation();
-          if (!Sammy.HashLocationProxy._last_location ||
+          if (typeof Sammy.HashLocationProxy._last_location == 'undefined' ||
             current_location != Sammy.HashLocationProxy._last_location) {
             window.setTimeout(function() {
               $(window).trigger('hashchange', [true]);


### PR DESCRIPTION
When a page loads with no hash, Sammy.HashLocationProxy._last_location == '', so this condition remains true and 'hashchange' is spuriously triggered over and over. It should only be triggered at initial page load (then _last_location is undefined) and when the hash actually changes.
