### PR TITLE
Minor bug fix in _decode

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -14,7 +14,7 @@
       // borrowed from jQuery
       _isFunction = function( obj ) { return Object.prototype.toString.call(obj) === "[object Function]"; },
       _isArray = function( obj ) { return Object.prototype.toString.call(obj) === "[object Array]"; },
-      _decode = function( str ) { return decodeURIComponent(str.replace(/\+/g, ' ')); },
+      _decode = function( str ) { return decodeURIComponent((str || '').replace(/\+/g, ' ')); },
       _encode = encodeURIComponent,
       _escapeHTML = function(s) {
         return String(s).replace(/&(?!\w+;)/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');


### PR DESCRIPTION
_decode should be able to handle undefined arguments in order to deal with routes with optional params; right now, if you have a route like '#/map(?:/:location)?', it will end up calling _decode with undefined when you try to process the bare '#/map' route without the optional parameters. This just adds a (str || '') check to the function.
