### PR TITLE
Sammy.Haml plugin doesn't work with IE

### DIFF
--- a/lib/plugins/sammy.haml.js
+++ b/lib/plugins/sammy.haml.js
@@ -1,9 +1,123 @@
+
+  /*
+    Additional methods on Array prototype that haml-js expects, but IE does not support.
+  */
+
+(function() {
+  if (!Array.prototype.forEach) {
+    Array.prototype.forEach = function(fun /*, thisp */) {
+      "use strict";
+
+      if (this === void 0 || this === null)
+        throw new TypeError();
+
+      var t = Object(this);
+      var len = t.length >>> 0;
+      if (typeof fun !== "function")
+        throw new TypeError();
+
+      var thisp = arguments[1];
+      for (var i = 0; i < len; i++) {
+        if (i in t)
+          fun.call(thisp, t[i], i, t);
+      }
+    };
+  }
+
+  if (typeof String.prototype.trim !== 'function') {
+    String.prototype.trim = function() {
+      return this.replace(/^\s+|\s+$/g, '');
+    };
+  }
+
+  if (!Array.prototype.map) {
+    Array.prototype.map = function(fun /*, thisp*/) {
+      var len = this.length;
+      if (typeof fun != "function")
+        throw new TypeError();
+
+      var res = new Array(len);
+      var thisp = arguments[1];
+      for (var i = 0; i < len; i++) {
+        if (i in this)
+          res[i] = fun.call(thisp, this[i], i, this);
+      }
+
+      return res;
+    };
+  }
+
+  if (!Array.prototype.filter) {
+    Array.prototype.filter = function(fun /*, thisp */) {
+      "use strict";
+
+      if (this === void 0 || this === null)
+        throw new TypeError();
+
+      var t = Object(this);
+      var len = t.length >>> 0;
+      if (typeof fun !== "function")
+        throw new TypeError();
+
+      var res = [];
+      var thisp = arguments[1];
+      for (var i = 0; i < len; i++) {
+        if (i in t) {
+          var val = t[i]; // in case fun mutates this
+          if (fun.call(thisp, val, i, t))
+            res.push(val);
+        }
+      }
+
+      return res;
+    };
+  }
+
+  if (!Array.prototype.indexOf) {
+    Array.prototype.indexOf = function(searchElement /*, fromIndex */)
+    {
+      "use strict";
+
+      if (this === void 0 || this === null)
+        throw new TypeError();
+
+      var t = Object(this);
+      var len = t.length >>> 0;
+      if (len === 0)
+        return -1;
+
+      var n = 0;
+      if (arguments.length > 0) {
+        n = Number(arguments[1]);
+        if (n !== n)
+          n = 0;
+        else if (n !== 0 && n !== (1 / 0) && n !== -(1 / 0))
+          n = (n > 0 || -1) * Math.floor(Math.abs(n));
+      }
+
+      if (n >= len)
+        return -1;
+
+      var k = n >= 0
+        ? n
+        : Math.max(len - Math.abs(n), 0);
+
+      for (; k < len; k++) {
+        if (k in t && t[k] === searchElement)
+          return k;
+      }
+      return -1;
+    };
+  }
+})();
+
 (function($) {
 
   /*
     port of http://github.com/creationix/haml-js
     version v0.2.6pre - 2010-10-01
     by Tim Caswell <tim@creationix.com>
+    additions by Rajat Vig (@rajatvig) to add proper IE support
   */
 
   var matchers, self_close_tags, embedder, forceXML;
@@ -73,11 +187,10 @@
 
     function process_pair() {
       if (typeof pair.start === 'number' &&
-          typeof pair.middle === 'number' &&
-          typeof pair.end === 'number') {
-        var key = line.substr(pair.start, pair.middle - pair.start).trim(),
-            value = line.substr(pair.middle + 1, pair.end - pair.middle - 1).trim();
-        attributes[key] = value;
+        typeof pair.middle === 'number' &&
+        typeof pair.end === 'number') {
+        var key = line.substr(pair.start, pair.middle - pair.start).trim();
+        attributes[key] = line.substr(pair.middle + 1, pair.end - pair.middle - 1).trim();
       }
       pair = {
         start: null,
@@ -273,7 +386,7 @@
 
     // declarations
     {
-      regexp: /^()!!!(?:\s*(.*))\s*$/,
+      regexp: /^!!!(?:\s*(.*))\s*$/,
       process: function () {
         var line = '';
         switch ((this.matches[2] || '').toLowerCase()) {
@@ -346,7 +459,7 @@
           this.contents.join("\n") +
           "\n</style>\n");
       }
-    },
+    }
 
   ];
 
@@ -364,7 +477,7 @@
 
       // Collect all text as raw until outdent
       if (block) {
-        match = block.check_indent(line);
+        match = block.check_indent.exec(line);
         if (match) {
           block.contents.push(match[1] || "");
           return;
@@ -376,7 +489,7 @@
 
       matchers.forEach(function (matcher) {
         if (!found) {
-          match = matcher.regexp(line);
+          match = matcher.regexp.exec(line);
           if (match) {
             block = {
               contents: [],
@@ -384,7 +497,7 @@
               check_indent: new RegExp("^(?:\\s*|" + match[1] + "  (.*))$"),
               process: matcher.process,
               render_contents: function () {
-                return compile(this. contents);
+                return compile(this.contents);
               }
             };
             found = true;
@@ -430,7 +543,7 @@
       output.push(block.process());
     }
     return output.filter(function (part) { return part && part.length > 0}).join(" +\n");
-  };
+  }
 
   function optimize(js) {
     var new_js = [], buffer = [], part, end;
@@ -459,7 +572,7 @@
     });
     flush();
     return new_js.join("\n");
-  };
+  }
 
   function render(text, options) {
     options = options || {};
@@ -469,7 +582,7 @@
       js = Haml.optimize(js);
     }
     return execute(js, options.context || Haml, options.locals);
-  };
+  }
 
   function execute(js, self, locals) {
     return (function () {
@@ -482,7 +595,7 @@
 
       }
     }).call(self);
-  };
+  }
 
   Haml = function Haml(haml, xml) {
     forceXML = xml;


### PR DESCRIPTION
Hi.

Since haml-js is meant to be used server side they have decided to not include IE support in their version. In Sammy on the other hand, client side rendering is a lot more useful. Is there a reason why IE support is not included in the Sammy.Haml plugin? The details of what is required can be found in this issue: https://github.com/creationix/haml-js/issues/26

I've attached the required changes based on @rajatvig work.
