### PR TITLE
Fix for GA plugin async ga code.

### DIFF
--- a/lib/plugins/sammy.googleanalytics.js
+++ b/lib/plugins/sammy.googleanalytics.js
@@ -66,7 +66,7 @@
       },
       // send a page view to the tracker with `path`
       track: function(path) {
-        if(typeof _tracker != 'undefined' && shouldTrack) {
+        if((typeof _tracker != 'undefined' || typeof _gaq != "undefined") && shouldTrack) {
           this.log('tracking', path);
           trackPageview(path);
         }


### PR DESCRIPTION
Fixed issue #96. GA plugin didn't work with async code. Now checks existence of _gaq in this.helpers.track().
