### PR TITLE
matching verb arrays

### DIFF
--- a/examples/backend/public/javascripts/sammy.js
+++ b/examples/backend/public/javascripts/sammy.js
@@ -1026,7 +1026,7 @@
       }
       var path_matched = true, verb_matched = true;
       if (options.path) {
-        // wierd regexp test
+        // weird regexp test
         if ($.isFunction(options.path.test)) {
           path_matched = options.path.test(context.path);
         } else {
@@ -1034,7 +1034,11 @@
         }
       }
       if (options.verb) {
-        verb_matched = options.verb === context.verb;
+        if(typeof options.verb === 'string') {
+          verb_matched = options.verb === context.verb;
+        } else {
+          verb_matched = options.verb.indexOf(context.verb) > -1;
+        }
       }
       return positive ? (verb_matched && path_matched) : !(verb_matched && path_matched);
     },

--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -1102,7 +1102,11 @@
         path_matched = options.path.test(context.path);
       }
       if (options.verb) {
-        verb_matched = options.verb === context.verb;
+        if(typeof options.verb === 'string') {
+          verb_matched = options.verb === context.verb;
+        } else {
+          verb_matched = options.verb.indexOf(context.verb) > -1;
+        }
       }
       return positive ? (verb_matched && path_matched) : !(verb_matched && path_matched);
     },

--- a/test/test_sammy_application.js
+++ b/test/test_sammy_application.js
@@ -956,6 +956,10 @@
         ok(this.app.contextMatchesOptions(this.route, {only: {verb: 'get'}}));
         ok(!this.app.contextMatchesOptions(this.route, {only: {verb: 'put'}}));
       })
+      .should('match against only with verb array', function() {
+        ok(this.app.contextMatchesOptions(this.route, {only: {verb: ['get', 'post']}}));
+        ok(!this.app.contextMatchesOptions(this.route, {only: {verb: ['put', 'post']}}));
+      })
       .should('match against except with path and verb', function() {
         ok(this.app.contextMatchesOptions(this.route, {except: {path: '#/', verb: 'get'}}));
         ok(!this.app.contextMatchesOptions(this.route, {except: {path: '#/boosh', verb: 'get'}}));


### PR DESCRIPTION
I found it useful to be able to provide verb arrays instead of just single verbs in before filters. So for example:

this.before({only: {verb: ['post', 'put']}}, function() {});
