### PR TITLE
this.log within an app will prepend the element_selector, so you know which app it is

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -508,6 +508,12 @@
       }
     },
 
+	// provide log() override for inside an app that includes the relevant application element_selector
+    log: function() {
+      Sammy.log.apply(Sammy, Array.prototype.concat.apply([this.element_selector],arguments));
+    },
+	
+	
     // `route()` is the main method for defining routes within an application.
     // For great detail on routes, check out:
     // [http://sammyjs.org/docs/routes](http://sammyjs.org/docs/routes)


### PR DESCRIPTION
Added log function to Sammy.Application which adds the element_selector, so you can tell which app is running

Typical log output is changed from:

[Wed Sep 28 2011 10:03:14 GMT+0300 (IDT)] runRoute get /Users/adeitcher/Documents/Development/JavaScript/SammyJS/src/sammy/test/index.html#/
sammy.js (line 100)

to:

[Wed Sep 28 2011 10:03:14 GMT+0300 (IDT)] body runRoute get /Users/adeitcher/Documents/Development/JavaScript/SammyJS/src/sammy/test/index.html#/
sammy.js (line 100)
