### PR TITLE
contextMatchesOptions + path array

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -1118,14 +1118,14 @@
         options = {path: options};
       }
       // Do we have to match against multiple paths?
-      if (options.path instanceof Array){
+      if (_isArray(options.path)){
         var results, numopt, opts;
         results = [];
         for (numopt in options.path){
           opts = $.extend({}, options, {path: options.path[numopt]});
           results.push(this.contextMatchesOptions(context, opts));
         }
-        var matched = results.indexOf(true) > -1 ? true : false;
+        var matched = $.inArray(true, results) > -1 ? true : false;
         return positive ? matched : !matched;
       }
       if (options.only) {

--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -512,8 +512,8 @@
     log: function() {
       Sammy.log.apply(Sammy, Array.prototype.concat.apply([this.element_selector],arguments));
     },
-	
-	
+
+
     // `route()` is the main method for defining routes within an application.
     // For great detail on routes, check out:
     // [http://sammyjs.org/docs/routes](http://sammyjs.org/docs/routes)
@@ -1094,6 +1094,15 @@
     //     // match all except a path
     //     app.contextMatchesOptions(context, {except: {path:'#/otherpath'}}); //=> true
     //     app.contextMatchesOptions(context, {except: {path:'#/mypath'}}); //=> false
+    //     // match multiple paths
+    //     app.contextMatchesOptions(context, {path: ['#/mypath', '#/otherpath']}); //=> true
+    //     app.contextMatchesOptions(context, {path: ['#/otherpath', '#/thirdpath']}); //=> false
+    //     // equivalent to
+    //     app.contextMatchesOptions(context, {only: {path: ['#/mypath', '#/otherpath']}}); //=> true
+    //     app.contextMatchesOptions(context, {only: {path: ['#/otherpath', '#/thirdpath']}}); //=> false
+    //     // match all except multiple paths
+    //     app.contextMatchesOptions(context, {except: {path: ['#/mypath', '#/otherpath']}}); //=> false
+    //     app.contextMatchesOptions(context, {except: {path: ['#/otherpath', '#/thirdpath']}}); //=> true
     //
     contextMatchesOptions: function(context, match_options, positive) {
       // empty options always match
@@ -1107,6 +1116,17 @@
       // normalize options
       if (typeof options === 'string' || _isFunction(options.test)) {
         options = {path: options};
+      }
+      // Do we have to match against multiple paths?
+      if (options.path instanceof Array){
+        var results, numopt, opts;
+        results = [];
+        for (numopt in options.path){
+          opts = $.extend({}, options, {path: options.path[numopt]});
+          results.push(this.contextMatchesOptions(context, opts));
+        }
+        var matched = results.indexOf(true) > -1 ? true : false;
+        return positive ? matched : !matched;
       }
       if (options.only) {
         return this.contextMatchesOptions(context, options.only, true);
@@ -1535,7 +1555,7 @@
             context.load(partials[name])
                    .then(function(template) {
                      this.partials[name] = template;
-                   });              
+                   });
           })(this, name);
         }
       }

--- a/test/test_sammy_application.js
+++ b/test/test_sammy_application.js
@@ -975,6 +975,30 @@
         ok(!this.app.contextMatchesOptions(this.route, {except: {verb: 'get'}}));
         ok(this.app.contextMatchesOptions(this.route, {except: {verb: 'put'}}));
       })
+      .should('match against path array', function(){
+        ok(!this.app.contextMatchesOptions(this.route, {path: ['#/', '#/foo']}));
+        ok(this.app.contextMatchesOptions(this.route, {path: ['#/', '#/boosh']}));
+        ok(!this.app.contextMatchesOptions(this.route, {only: {path: ['#/', '#/foo']}}));
+        ok(this.app.contextMatchesOptions(this.route, {only: {path: ['#/', '#/boosh']}}));
+        ok(this.app.contextMatchesOptions(this.route, {except: {path: ['#/', '#/foo']}}));
+        ok(!this.app.contextMatchesOptions(this.route, {except: {path: ['#/', '#/boosh']}}));
+      })
+      .should('match against path array with verb', function(){
+        ok(this.app.contextMatchesOptions(this.route, {path: ['#/', '#/boosh'], verb: 'get'}));
+        ok(!this.app.contextMatchesOptions(this.route, {path: ['#/', '#/boosh'], verb: 'put'}));
+        ok(!this.app.contextMatchesOptions(this.route, {only: {path: ['#/', '#/boosh'], verb: 'put'}}));
+        ok(this.app.contextMatchesOptions(this.route, {only: {path: ['#/', '#/boosh'], verb: 'get'}}));
+        ok(this.app.contextMatchesOptions(this.route, {except: {path: ['#/', '#/boosh'], verb: 'put'}}));
+        ok(!this.app.contextMatchesOptions(this.route, {except: {path: ['#/', '#/boosh'], verb: 'get'}}));
+      })
+      .should('match against path array with verb array', function(){
+        ok(this.app.contextMatchesOptions(this.route, {path: ['#/', '#/boosh'], verb: ['get', 'put']}));
+        ok(!this.app.contextMatchesOptions(this.route, {path: ['#/', '#/boosh'], verb: ['put', 'post']}));
+        ok(!this.app.contextMatchesOptions(this.route, {only: {path: ['#/', '#/boosh'], verb: ['put', 'post']}}));
+        ok(this.app.contextMatchesOptions(this.route, {only: {path: ['#/', '#/boosh'], verb: ['put', 'get']}}));
+        ok(this.app.contextMatchesOptions(this.route, {except: {path: ['#/', '#/boosh'], verb: ['put', 'post']}}));
+        ok(!this.app.contextMatchesOptions(this.route, {except: {path: ['#/', '#/boosh'], verb: ['put', 'get']}}));
+      })
       .should('match against just path', function() {
         ok(this.app.contextMatchesOptions(this.route, '#/boosh'), 'should match exact string path');
         ok(!this.app.contextMatchesOptions(this.route, '#/boo'), 'should not match partial string path');


### PR DESCRIPTION
Hi

I'm using `this.before` but need to exclude multiple paths. Someone on the group had this problem too [0] and the proposed solution was to add a single regex handling all paths. That's fine with a low number of paths - else it gets very unreadable and a pain to maintain.

I've added support for `Sammy.Application.contextMatchesOptions` to take a path array. Taken from the code:

```
var app = $.sammy(),
    context = {verb: 'get', path: '#/mypath'};

// match multiple paths
app.contextMatchesOptions(context, {path: ['#/mypath', '#/otherpath']}); //=> true
app.contextMatchesOptions(context, {path: ['#/otherpath', '#/thirdpath']}); //=> false
// equivalent to
app.contextMatchesOptions(context, {only: {path: ['#/mypath', '#/otherpath']}}); //=> true
app.contextMatchesOptions(context, {only: {path: ['#/otherpath', '#/thirdpath']}}); //=> false
// match all except multiple paths
app.contextMatchesOptions(context, {except: {path: ['#/mypath', '#/otherpath']}}); //=> false
app.contextMatchesOptions(context, {except: {path: ['#/otherpath', '#/thirdpath']}}); //=> true
```

[0] https://groups.google.com/d/topic/sammyjs/5twqVEOyl6c/discussion
