### PR TITLE
Fixed issue when multiple params with the same name are passed with empty values

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -1297,7 +1297,7 @@
     },
 
     _parseParamPair: function(params, key, value) {
-      if (params[key]) {
+      if (typeof params[key] !== 'undefined') {
         if (_isArray(params[key])) {
           params[key].push(value);
         } else {


### PR DESCRIPTION
I recently ran into a problem where I had multiple form inputs with the same name when empty values are sent.

For example, if a parameter list looked like the following:

```
?slides=foo&slides=bar&slides=baz&timeouts=&timeouts=1000&timeouts=
```

In the route handling this request, I would expect this as the `app.params` list:

```
{
  slides: ['foo', 'bar', 'baz'],
  timeouts: ['', '1000', '']
}
```

But instead, you'll receive:

```
{
  slides: ['foo', 'bar', 'baz'],
  timeouts: ['1000', '']
}
```

Or if an entire set of inputs are empty, let's say `timeouts`, it'll look like this:

```
{
  slides: ['foo', 'bar', 'baz'],
  timeouts: ''
}
```
