### PR TITLE
Bug with loading of multiple partials

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -1528,17 +1528,18 @@
     //      this.loadPartials({mypartial: '/path/to/partial'});
     //
     loadPartials: function(partials) {
-      if(partials) {
-        this.partials = this.partials || {};
-        for(name in partials) {
-          (function(context, name) {
-            context.load(partials[name])
-                   .then(function(template) {
-                     this.partials[name] = template;
-                   });              
-          })(this, name);
-        }
-      }
+	  if(partials) {
+	    var that = this;
+	    that.partials = that.partials || {};
+	    for(name in partials) {
+	      (function(name, partials) {
+		    that.load(partials[name])
+	            .then(function(template) {
+	              that.partials[name] = template;
+	            });
+	      }(name, partials));
+	    }
+	  }
       return this;
     },
 


### PR DESCRIPTION
Fixed bug with loading multiple partials. The problem was scoping of the 'name' variable. The loading is async but used a varable which the for-loop changed. This fix uses a self-executing function to create correct scoping.
