### PR TITLE
DefaultLocationProxy tries to handle every link on the page

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -1528,6 +1528,7 @@
     //      this.loadPartials({mypartial: '/path/to/partial'});
     //
     loadPartials: function(partials) {
+      var name;
       if(partials) {
         this.partials = this.partials || {};
         for(name in partials) {

--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -262,6 +262,9 @@
         });
         // bind to link clicks that have routes
         $('a').live('click.history-' + this.app.eventNamespace(), function(e) {
+          if (e.isDefaultPrevented()) {
+            return;
+          }
           var full_path = lp.fullPath(this);
           if (this.hostname == window.location.hostname && app.lookupRoute('get', full_path)) {
             e.preventDefault();


### PR DESCRIPTION
This patch adds a simple check to `DefaultLocationProxy` to ignore events that have `preventDefault` called on them.

This is an issue when attaching event handlers outside the Sammy app to links that trigger gui actions, or use the link's `href` as a fallback for when js is disabled, and there are "greedy" routes (as in `get(/\/$/)` to match the homepage, but will also match any path that ends with a slash).

Currently the only way to accomplish this is to stop the event's propagation, which I think should not be required. 
