### PR TITLE
Fix for logging in IE8

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -101,7 +101,7 @@
       });
     } else {
       Sammy.addLogger(function() {
-        window.console.log(arguments);
+        window.console.log(_makeArray(arguments).join(' '));
       });
     }
   } else if (typeof console != 'undefined') {


### PR DESCRIPTION
Currently all that Sammy logs to the IE8 developer 
tools is "LOG: [object Object]". Not very useful 
when you are trying to debug an IE8 issue! This 
fix makes it work OK in IE8 and shouldn't effect
any other browser detrimentally.
