### PR TITLE
contextMatchesOptions tests fail

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -1110,7 +1110,7 @@
     contextMatchesOptions: function(context, match_options, positive) {
       // empty options always match
       var options = match_options;
-      if (typeof options === 'undefined' || $.isPlainObject(options)) {
+      if (typeof options === 'undefined' || $.isEmptyObject(options)) {
         return true;
       }
       if (typeof positive === 'undefined') {


### PR DESCRIPTION
In version 0.7.1 most contextMatchesOptions tests fail.
This should fix it.
