### PR TITLE
partials support

### DIFF
--- a/lib/plugins/sammy.tmpl.js
+++ b/lib/plugins/sammy.tmpl.js
@@ -17,22 +17,14 @@
     // * `template` A String template. '${ }' tags are evaluated as Javascript and replaced with the elements in data.
     // * `data` An Object containing the replacement values for the template.
     //   data is extended with the <tt>EventContext</tt> allowing you to call its methods within the template.
-    // * `partials` Additional templates.
+    // * `name` An optional String name to cache the template.
     //
-    var template = function(template, data, partials) {
-      var name;
-
+    var template = function(template, data, name) {
       // use name for caching
       if (typeof name == 'undefined') { name = template; }
 
-      if (typeof partials == 'undefined') {
-        // check the cache
-        if (!jQuery.template[name]) { jQuery.template(name, template); }
-      } else {
-        for (partial in partials) {
-          if (!jQuery.template[partial]) { jQuery.template(partial, partials[partial]); }
-        }
-      }
+      // check the cache
+      if (!jQuery.template[name]) { jQuery.template(name, template); }
 
       // we could also pass along jQuery-tmpl options as a last param?
       return jQuery.tmpl(name, jQuery.extend({}, this, data));

--- a/lib/plugins/sammy.tmpl.js
+++ b/lib/plugins/sammy.tmpl.js
@@ -17,14 +17,22 @@
     // * `template` A String template. '${ }' tags are evaluated as Javascript and replaced with the elements in data.
     // * `data` An Object containing the replacement values for the template.
     //   data is extended with the <tt>EventContext</tt> allowing you to call its methods within the template.
-    // * `name` An optional String name to cache the template.
+    // * `partials` Additional templates.
     //
-    var template = function(template, data, name) {
+    var template = function(template, data, partials) {
+      var name;
+
       // use name for caching
       if (typeof name == 'undefined') { name = template; }
 
-      // check the cache
-      if (!jQuery.template[name]) { jQuery.template(name, template); }
+      if (typeof partials == 'undefined') {
+        // check the cache
+        if (!jQuery.template[name]) { jQuery.template(name, template); }
+      } else {
+        for (partial in partials) {
+          if (!jQuery.template[partial]) { jQuery.template(partial, partials[partial]); }
+        }
+      }
 
       // we could also pass along jQuery-tmpl options as a last param?
       return jQuery.tmpl(name, jQuery.extend({}, this, data));

--- a/lib/plugins/sammy.tmpl.js
+++ b/lib/plugins/sammy.tmpl.js
@@ -17,14 +17,20 @@
     // * `template` A String template. '${ }' tags are evaluated as Javascript and replaced with the elements in data.
     // * `data` An Object containing the replacement values for the template.
     //   data is extended with the <tt>EventContext</tt> allowing you to call its methods within the template.
-    // * `name` An optional String name to cache the template.
+    // * `partials` An Object containing one or more partials (String templates
+    //   that are called from the main template).
     //
-    var template = function(template, data, name) {
+    var template = function(template, data, partials) {
       // use name for caching
-      if (typeof name == 'undefined') { name = template; }
+      var name = template
 
       // check the cache
       if (!jQuery.template[name]) { jQuery.template(name, template); }
+
+      partials = $.extend({}, data.partials, partials);
+      for (partial in partials) {
+        if (!jQuery.template[partial]) { jQuery.template(partial, partials[partial]); }
+      }
 
       // we could also pass along jQuery-tmpl options as a last param?
       return jQuery.tmpl(name, jQuery.extend({}, this, data));

--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -1584,23 +1584,28 @@
       if (_isFunction(location) && !data) {
         return this.then(location);
       } else {
-        return this.loadPartials(partials)
-                   .load(location)
-                   .interpolate(data, location)
-                   .then(callback);
+        if (typeof partials == 'object') {
+          this.loadPartials(partials)
+              // pass through template name
+              .then(function() { return location});
+        } else {
+          this.load(location);
+        }
+        return this.interpolate(data, location)
+            .then(callback);
       }
     },
 
     // `render()` the `location` with `data` and then `swap()` the
     // app's `$element` with the rendered content.
-    partial: function(location, data, callback) {
+    partial: function(location, data, callback, partials) {
       if (_isFunction(callback)) {
-        return this.render(location, data).swap(callback);
+        return this.render(location, data, undefined, partials).swap(callback);
       } else if (!callback && _isFunction(data)) {
         // invoked as partial(location, callback)
-        return this.render(location).swap(data);
+        return this.render(location, undefined, undefined, partials).swap(data);
       } else {
-        return this.render(location, data).swap();
+        return this.render(location, data, undefined, partials).swap();
       }
     },
 
@@ -1874,8 +1879,18 @@
 
     // `render()` the `location` with `data` and then `swap()` the
     // app's `$element` with the rendered content.
-    partial: function(location, data, callback) {
-      return new Sammy.RenderContext(this).partial(location, data, callback);
+    partial: function(location, data, callback, partials) {
+      if (typeof data == 'function') {
+        // called as partial(location, callback)
+        partials = callback;
+        callback = data;
+        data = undefined;
+      } else if (typeof callback == 'object') {
+        // called as partial(location, data, partials)
+        partials = callback;
+        callback = undefined;
+      }
+      return new Sammy.RenderContext(this).partial(location, data, callback, partials);
     },
 
     // create a new `Sammy.RenderContext` calling `send()` with an arbitrary

--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -1584,28 +1584,23 @@
       if (_isFunction(location) && !data) {
         return this.then(location);
       } else {
-        if (typeof partials == 'object') {
-          this.loadPartials(partials)
-              // pass through template name
-              .then(function() { return location});
-        } else {
-          this.load(location);
-        }
-        return this.interpolate(data, location)
-            .then(callback);
+        return this.loadPartials(partials)
+                   .load(location)
+                   .interpolate(data, location)
+                   .then(callback);
       }
     },
 
     // `render()` the `location` with `data` and then `swap()` the
     // app's `$element` with the rendered content.
-    partial: function(location, data, callback, partials) {
+    partial: function(location, data, callback) {
       if (_isFunction(callback)) {
-        return this.render(location, data, undefined, partials).swap(callback);
+        return this.render(location, data).swap(callback);
       } else if (!callback && _isFunction(data)) {
         // invoked as partial(location, callback)
-        return this.render(location, undefined, undefined, partials).swap(data);
+        return this.render(location).swap(data);
       } else {
-        return this.render(location, data, undefined, partials).swap();
+        return this.render(location, data).swap();
       }
     },
 
@@ -1879,18 +1874,8 @@
 
     // `render()` the `location` with `data` and then `swap()` the
     // app's `$element` with the rendered content.
-    partial: function(location, data, callback, partials) {
-      if (typeof data == 'function') {
-        // called as partial(location, callback)
-        partials = callback;
-        callback = data;
-        data = undefined;
-      } else if (typeof callback == 'object') {
-        // called as partial(location, data, partials)
-        partials = callback;
-        callback = undefined;
-      }
-      return new Sammy.RenderContext(this).partial(location, data, callback, partials);
+    partial: function(location, data, callback) {
+      return new Sammy.RenderContext(this).partial(location, data, callback);
     },
 
     // create a new `Sammy.RenderContext` calling `send()` with an arbitrary

--- a/test/test_sammy_plugins.js
+++ b/test/test_sammy_plugins.js
@@ -370,11 +370,11 @@
           var rendered = this.context.tmpl('<div class="test_class">${text} ${blurgh}</div>', {text: 'TEXT!'});
           sameHTML(rendered, '<div class="test_class">TEXT! boosh</div>');
         })
-//        .should('allow tmpl partials by passing partials to data', function() {
-//          var data = {blurgh: 'fizzzz', partials: {first: 'a ${what}'}, what: 'partial'};
-//          var rendered = this.context.tmpl('<div class="test_class">{{tmpl partials.first}} ${blurgh}</div>', data);
-//          sameHTML(rendered, '<div class="test_class">a partial boosh</div>');
-//        })
+        .should('allow tmpl partials by passing partials to data', function() {
+          var data = {blurgh: 'fizzzz', partials: {first: 'a ${what}'}, what: 'partial'};
+          var rendered = this.context.tmpl('<div class="test_class">{{tmpl "first"}} ${blurgh}</div>', data);
+          sameHTML(rendered, '<div class="test_class">a partial fizzzz</div>');
+        })
         .should('alias the tmpl method and thus the extension', function() {
           ok(!$.isFunction(this.alias_context.tmpl));
           ok($.isFunction(this.alias_context.jqt));


### PR DESCRIPTION
I could not understand how partials are supposed to work and developed this fix to let the following work with jQuery.Tmpll:

context.partial('main', {}, {'main': 'template.html', 'part': 'template/part.hml'})

Fix has two things, support for above notation in sammy.js and support for partials in sammy.tmpl.js
