### PR TITLE
extend prototypes rather than creating them from scratch

### DIFF
--- a/lib/plugins/sammy.data_location_proxy.js
+++ b/lib/plugins/sammy.data_location_proxy.js
@@ -38,7 +38,7 @@
     this.href_attribute = href_attribute;
   };
 
-  Sammy.DataLocationProxy.prototype = {
+$.extend(Sammy.DataLocationProxy.prototype , {
     bind: function() {
       var proxy = this;
       this.app.$element().bind('setData', function(e, key, value) {
@@ -73,6 +73,6 @@
     setLocation: function(new_location) {
       return this.app.$element().data(this.data_name, new_location);
     }
-  };
+  });
 
 })(jQuery);

--- a/lib/plugins/sammy.flash.js
+++ b/lib/plugins/sammy.flash.js
@@ -6,7 +6,7 @@
     this.now = {};
   };
 
-  Sammy.FlashHash.prototype = {
+$.extend(Sammy.FlashHash.prototype , {
     // @return [String] this Flash, rendered as an <ul>.
     toHTML: function() {
       var result = this._renderUL();
@@ -54,7 +54,7 @@
       Sammy.log('rendered flash: ' + result);
       return result;
     }
-  };
+  });
 
   // Sammy.Flash is a plugin for storing and sending status messages to the client. It's API and use
   // is similar to Ruby on Rails' `flash` explained here:

--- a/lib/plugins/sammy.path_location_proxy.js
+++ b/lib/plugins/sammy.path_location_proxy.js
@@ -13,7 +13,7 @@
     this.app = app;
   };
 
-  Sammy.PathLocationProxy.prototype = {
+  $.extend(Sammy.PathLocationProxy.prototype , {
     bind: function() {},
     unbind: function() {},
 
@@ -24,6 +24,6 @@
     setLocation: function(new_location) {
       return window.location = new_location;
     }
-  };
+  });
 
 })(jQuery);

--- a/lib/plugins/sammy.push_location_proxy.js
+++ b/lib/plugins/sammy.push_location_proxy.js
@@ -24,7 +24,7 @@
         this.app = app;
     };
 
-    Sammy.PushLocationProxy.prototype = {
+    $.extend(Sammy.PushLocationProxy.prototype , {
       bind: function() {
         var proxy = this;
         $(window).bind('popstate', function(e) {
@@ -51,6 +51,6 @@
       setLocation: function(new_location) {
         history.pushState({ path: this.path }, '', new_location);
       }
-    };
+    });
 
 })(jQuery);

--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -242,7 +242,7 @@
     var hash = matches ? matches[1] : '';
     return [location_obj.pathname, location_obj.search, hash].join('');
   };
-  Sammy.DefaultLocationProxy.prototype = {
+$.extend(Sammy.DefaultLocationProxy.prototype , {
     // bind the proxy events to the current app.
     bind: function() {
       var proxy = this, app = this.app, lp = Sammy.DefaultLocationProxy;
@@ -334,7 +334,7 @@
         Sammy.DefaultLocationProxy._interval = window.setInterval(hashCheck, every);
       }
     }
-  };
+  });
 
 
   // Sammy.Application is the Base prototype for defining 'applications'.


### PR DESCRIPTION
I've been writing some coffeeScript to inherit one of the classes in Sammy like this:

```
class DataLocationProxyTest extends Sammy.DataLocationProxy
    setLocation : (newLocation) ->
        super newLocation
```

With the way DataLocationProxy is written this doesn't work because the constructor is not inherited.  To be inherited DataLocationProxy.prototype.constructor would have to be the DataLocationProxy function.

This is because the prototype is defined as a new object :

```
Sammy.DataLocationProxy.prototype = {
    bind: function() {
        var proxy = this;
        this.app.$element().bind('setData', function(e, key, value) {
            if (key == proxy.data_name) {
......
```

if the prototype is defined like this :
    $.extend(Sammy.DataLocationProxy.prototype, {bind : function() {
        var proxy = this;
    .....
unbind : function() {
        if (this.href_attribute) {

&c then it is possible to inherit 

Is there any reason that the prototypes are defined as they are and would it be better to extend rather than redefine them so that classes can be inherited?  I note in other places it uses $.extend which does not cause this problem.

The code in this pull request uses $.extend for the modification of all prototypes.
