### PR TITLE
Made compliant with AMD loaders with global fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp/*
 _layouts
 _site
 .DS_Store
+*.swp

--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -4,7 +4,16 @@
 // Sammy.js / http://sammyjs.org
 
 (function($, window) {
-
+  (function(factory){
+    // Support module loading scenarios
+    if (typeof define === 'function' && define['amd']){
+      // AMD Anonymous Module
+      define(['jquery'], factory);
+    } else {
+      // No module loader (plain <script> tag) - put directly in global namespace
+      $.sammy = window.Sammy = factory($);
+    }
+  })(function($){
   var Sammy,
       PATH_REPLACER = "([^\/]+)",
       PATH_NAME_MATCHER = /:([\w\d]+)/g,
@@ -1962,7 +1971,6 @@
 
   });
 
-  // An alias to Sammy
-  $.sammy = window.Sammy = Sammy;
-
+  return Sammy;
+});
 })(jQuery, window);


### PR DESCRIPTION
Made compatible with AMD loaders following the Universal Module Definition pattern as laid out by @jrburke at https://github.com/umdjs/umd

For detailed description of what AMD is See: http://addyosmani.com/writing-modular-js/
