### PR TITLE
Namespace-friendly define.amd check

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -6,7 +6,7 @@
 (function($, window) {
   (function(factory){
     // Support module loading scenarios
-    if (typeof define === 'function' && define['amd']){
+    if (typeof define === 'function' && define.amd){
       // AMD Anonymous Module
       define(['jquery'], factory);
     } else {


### PR DESCRIPTION
This change allows the code to participate in the namespace build option for the requirejs optimizer and is fewer bytes.
