### PR TITLE
Added a check on an href's target attribute. 

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -275,7 +275,9 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
             return;
           }
           var full_path = lp.fullPath(this);
-          if (this.hostname == window.location.hostname && app.lookupRoute('get', full_path)) {
+          if (this.hostname == window.location.hostname &&
+              app.lookupRoute('get', full_path) &&
+              this.target !== '_blank') {
             e.preventDefault();
             proxy.setLocation(full_path);
             return false;


### PR DESCRIPTION
Namely that if the target is blank ie. open in new tab, then don't runt the route through sammy.
