### PR TITLE
Respect app.disable_push_state.

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -307,7 +307,7 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
     // set the current location to `new_location`
     setLocation: function(new_location) {
       if (/^([^#\/]|$)/.test(new_location)) { // non-prefixed url
-        if (_has_history) {
+        if (_has_history && !this.app.disable_push_state) {
           new_location = '/' + new_location;
         } else {
           new_location = '#!/' + new_location;
@@ -315,7 +315,7 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
       }
       if (new_location != this.getLocation()) {
         // HTML5 History exists and new_location is a full path
-        if (_has_history && /^\//.test(new_location)) {
+        if (_has_history && !this.app.disable_push_state && /^\//.test(new_location)) {
           history.pushState({ path: new_location }, window.title, new_location);
           this.app.trigger('location-changed');
         } else {


### PR DESCRIPTION
Code paths dependent on the HTML5 history API were not all checking for
the `disable_push_state` flag, making it impossible to downgrade
history-compliant browsers for testing. Added `disable_push_state` check
in relevant code paths.
