### PR TITLE
Mixpanel plugin

### DIFF
--- a/lib/plugins/sammy.googleanalytics.js
+++ b/lib/plugins/sammy.googleanalytics.js
@@ -74,7 +74,7 @@
     });
 
     this.bind('event-context-after', function() {
-      var path = app.last_location[1];
+      var path = this.app.last_location[1];
       if (path) {
         this.track(path);
         enableTracking();

--- a/lib/plugins/sammy.googleanalytics.js
+++ b/lib/plugins/sammy.googleanalytics.js
@@ -67,15 +67,18 @@
       // send a page view to the tracker with `path`
       track: function(path) {
         if((typeof _tracker != 'undefined' || typeof _gaq != "undefined") && shouldTrack) {
-          this.log('tracking', path);
+          this.log('tracking google analytics', path);
           trackPageview(path);
         }
       }
     });
 
     this.bind('event-context-after', function() {
-      this.track(this.path);
-      enableTracking();
+      var path = app.last_location[1];
+      if (path) {
+        this.track(path);
+        enableTracking();
+      }
     });
   };
 

--- a/lib/plugins/sammy.kissmetrics.js
+++ b/lib/plugins/sammy.kissmetrics.js
@@ -2,7 +2,7 @@
 
   Sammy = Sammy || {};
 
-  // A simple plugin that pings Mixpanel tracker
+  // A simple plugin that pings KISSmetrics tracker
   // every time a route is triggered. Created by Juan Pablo Garcia Dalolla
   // (jpgarcia), based on the Sammy.GoogleAnalytics 
   // plugin developed by Brit Gardner (britg) with updates from 
@@ -10,32 +10,32 @@
   //
   // ### Example
   //
-  // Install Mixpanel to your site as you normally would. Be sure that
-  // the 'mixpanel' global variable exists (it should be created by the
-  // script provided by Mixpanel).
+  // Install KISSmetrics to your site as you normally would. Be sure that
+  // the '_kmq' global variable exists (it should be created by the
+  // script provided by KISSmetrics).
   //
   // Then, simply add the plugin to your Sammy App and it will automatically
-  // track all of your routes in Mixpanel.
+  // track all of your routes in KISSmetrics.
   // They will appear as page views to the route's path.
   //
   //      $.sammy(function() {
-  //        this.use('Mixpanel');
+  //        this.use('KISSmetrics');
   //
   //        ...
   //      });
   //
   // If you have routes that you do not want to track, simply call 
-  // `doNotTrackMixpanel within the route.
+  // `doNotTrackKISSmetrics within the route.
   //
   //      $.sammy(function() {
-  //        this.use('Mixpanel')
+  //        this.use('KISSmetrics')
   //
   //        this.get('#/dont/track/me', function() {
-  //          this.doNotTrackMixpanel();  // This route will not be tracked
+  //          this.doNotTrackKISSmetrics();  // This route will not be tracked
   //        });
   //      });
   //
-  Sammy.Mixpanel = function(app) {
+  Sammy.KISSmetrics = function(app) {
     var shouldTrack = true;
 
     function disableTracking() {
@@ -49,14 +49,14 @@
     this.helpers({
       // Disable tracking for the current route. Put at the begining of the
       // route's callback
-      doNotTrackMixpanel: function() {
+      doNotTrackKISSmetrics: function() {
         disableTracking();
       },
       // send a page view to the tracker with `path`
-      trackMixpanel: function(path) {
-        if((typeof window.mixpanel != 'undefined') && shouldTrack) {
-          this.log('tracking mixpanel', path);
-          window.mixpanel.track(path);
+      trackKISSmetrics: function(path) {
+        if((typeof window._kmq != 'undefined') && shouldTrack) {          
+          this.log('tracking KISSmetrics', path);
+          window._kmq.push(['record', path]);
         }
       }
     });
@@ -65,7 +65,7 @@
       var path = this.app.last_location[1];
 
       if (path) {
-        this.trackMixpanel(path);
+        this.trackKISSmetrics(path);
         enableTracking();
       }
     });

--- a/lib/plugins/sammy.mixpanel.js
+++ b/lib/plugins/sammy.mixpanel.js
@@ -25,13 +25,13 @@
   //      });
   //
   // If you have routes that you do not want to track, simply call 
-  // `noTrackMixpanel within the route.
+  // `doNotTrackMixpanel within the route.
   //
   //      $.sammy(function() {
   //        this.use('Mixpanel')
   //
   //        this.get('#/dont/track/me', function() {
-  //          this.noTrackMixpanel();  // This route will not be tracked
+  //          this.doNotTrackMixpanel();  // This route will not be tracked
   //        });
   //      });
   //
@@ -49,7 +49,7 @@
     this.helpers({
       // Disable tracking for the current route. Put at the begining of the
       // route's callback
-      noTrackMixpanel: function() {
+      doNotTrackMixpanel: function() {
         disableTracking();
       },
       // send a page view to the tracker with `path`
@@ -62,7 +62,7 @@
     });
 
     this.bind('event-context-after', function() {
-      var path = app.last_location[1];
+      var path = this.app.last_location[1];
       if (path) {
         this.trackMixpanel(path);
         enableTracking();

--- a/lib/plugins/sammy.mixpanel.js
+++ b/lib/plugins/sammy.mixpanel.js
@@ -1,0 +1,73 @@
+(function($) {
+
+  Sammy = Sammy || {};
+
+  // A simple plugin that pings Mixpanel tracker
+  // every time a route is triggered. Created by Juan Pablo Garcia Dalolla
+  // (jpgarcia), based on the Sammy.GoogleAnalytics 
+  // plugin developed by Brit Gardner (britg) with updates from 
+  // Aaron Quint (quirkey).
+  //
+  // ### Example
+  //
+  // Install Mixpanel to your site as you normally would. Be sure that
+  // the 'mixpanel' global variable exists (it should be created by the
+  // script provided by Mixpanel).
+  //
+  // Then, simply add the plugin to your Sammy App and it will automatically
+  // track all of your routes in Mixpanel.
+  // They will appear as page views to the route's path.
+  //
+  //      $.sammy(function() {
+  //        this.use('Mixpanel');
+  //
+  //        ...
+  //      });
+  //
+  // If you have routes that you do not want to track, simply call 
+  // `noTrackMixpanel within the route.
+  //
+  //      $.sammy(function() {
+  //        this.use('Mixpanel')
+  //
+  //        this.get('#/dont/track/me', function() {
+  //          this.noTrackMixpanel();  // This route will not be tracked
+  //        });
+  //      });
+  //
+  Sammy.Mixpanel = function(app) {
+    var shouldTrack = true;
+
+    function disableTracking() {
+      shouldTrack = false;
+    }
+
+    function enableTracking() {
+      shouldTrack = true;
+    }
+
+    this.helpers({
+      // Disable tracking for the current route. Put at the begining of the
+      // route's callback
+      noTrackMixpanel: function() {
+        disableTracking();
+      },
+      // send a page view to the tracker with `path`
+      trackMixpanel: function(path) {
+        if((typeof window.mixpanel != 'undefined') && shouldTrack) {
+          this.log('tracking mixpanel', path);
+          window.mixpanel.track(path);
+        }
+      }
+    });
+
+    this.bind('event-context-after', function() {
+      var path = app.last_location[1];
+      if (path) {
+        this.trackMixpanel(path);
+        enableTracking();
+      }
+    });
+  };
+
+})(jQuery);


### PR DESCRIPTION
I've just added a new plugin for tracking page views on Mixpanel, hope you find it useful.

Also performed some tweaks on the Google Analytics plugin as I realized that when binding two 'event-context-after' events (e.g.:Google Analytics + Mixpanel plugins) you receive the path value as 'event-context-after' instead of the actual path on the 2nd plugin declared. So I updated to code to get the path from **app.last_location[1]** rather than from **this.path**.

Please let me know if there is a better approach to get this path and using both plugins at the same time.
