### PR TITLE
Update lib/sammy.js

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -936,10 +936,16 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
           app._unlisten(name, listener_callback);
         });
       });
-      delete Sammy.apps[this.element_selector];
       this._running = false;
       return this;
     },
+	
+	// calls unload() and remove any mention to the app
+	destroy: function() {
+	  this.unload();
+      delete Sammy.apps[this.element_selector];
+	  return this;
+	},
 
     // Will bind a single callback function to every event that is already
     // being listened to in the app. This includes all the `APP_EVENTS`

--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -936,6 +936,7 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
           app._unlisten(name, listener_callback);
         });
       });
+      delete Sammy.apps[this.element_selector];
       this._running = false;
       return this;
     },

--- a/test/application_spec.js
+++ b/test/application_spec.js
@@ -1148,5 +1148,21 @@ describe('Application', function() {
         expect(app.$element().attr('id')).to.eql('main');
       });
     });
+	
+    describe('#unload()', function() {
+      beforeEach(function() {
+        app = $.sammy('#main');
+		app.run();
+      });
+      
+      it('new application is created after unload', function() {
+		expect(Sammy.apps['#main']).to.be.an(Object);
+		app.unload();
+		expect(Sammy.apps['#main']).to.be(undefined);
+		
+		app2 = $.sammy('#main');
+		expect(app2).not.to.be.eql(app);
+      });
+    });
   });
 });

--- a/test/application_spec.js
+++ b/test/application_spec.js
@@ -1149,15 +1149,15 @@ describe('Application', function() {
       });
     });
 	
-    describe('#unload()', function() {
+    describe('#destroy()', function() {
       beforeEach(function() {
         app = $.sammy('#main');
 		app.run();
       });
       
-      it('new application is created after unload', function() {
+      it('removes any mention of the object', function() {
 		expect(Sammy.apps['#main']).to.be.an(Object);
-		app.unload();
+		app.destroy();
 		expect(Sammy.apps['#main']).to.be(undefined);
 		
 		app2 = $.sammy('#main');


### PR DESCRIPTION
In unload() the current selector must be removed from the Sammy.apps[]. Otherwise after unload() not a new Sammy app is creating but reactivating an unloaded one (and that makes impossible unit testing).
