### PR TITLE
Added support for asynchronous chaining, asynchronous finally, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ Inside the 'app' function() `this` is the Application. This is where you can con
 
 Above, we defined a `get()` route. When the browser is pointed to `#/` the function passed to that route will be run. Inside the route function, `this` is a Sammy.EventContext. EventContext has a bunch of special methods and properties including a params hash, the ability to redirect, render partials, and more.
 
+In its coolness, Sammy can handle multiple chained asynchronous callbacks on a route.
+
+    this.get('#/', function(context,next) {
+      $('#main').text('Welcome!');
+			$.get('/some/url',function(){
+				// save the data somewhere
+				next();
+			});
+    }, function(context,next) {
+			$.get('/some/other/url',function(){
+				// save this data too
+				next();
+			});
+		});
+
+
 Once you've defined an application the only thing left to do is run it. The best-practice behavior is to encapsulate `run()` in a document.ready block:
 
     var app = $.sammy(...)
@@ -85,6 +101,7 @@ Sammy.js was created and is maintained by Aaron Quint <aaron at quirkey.com> wit
 * kbuckler
 * dvv
 * Ben Vinegar / benvinegar
+* Avi Deitcher / deitch
 
 ## Donate!
 

--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -31,7 +31,9 @@
         return String(s).replace(/&(?!\w+;)/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
       },
       _routeWrapper = function(verb) {
-        return function(path, callback) { return this.route.apply(this, [verb, path, callback]); };
+        return function() { 
+					return this.route.apply(this, [verb].concat(Array.prototype.slice.call(arguments))); 
+				};
       },
       _template_cache = {},
       _has_history = !!(window.history && history.pushState),
@@ -547,14 +549,14 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
     //    It is also possible to pass a string as the callback, which is looked up as the name
     //    of a method on the application.
     //
-    route: function(verb, path, callback) {
-      var app = this, param_names = [], add_route, path_match;
+    route: function(verb, path) {
+      var app = this, param_names = [], add_route, path_match, callback = Array.prototype.slice.call(arguments,2);
 
       // if the method signature is just (path, callback)
       // assume the verb is 'any'
-      if (!callback && _isFunction(path)) {
+      if (callback.length === 0 && _isFunction(path)) {
         path = verb;
-        callback = path;
+        callback = [path];
         verb = 'any';
       }
 
@@ -575,10 +577,12 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
         // replace with the path replacement
         path = new RegExp(path.replace(PATH_NAME_MATCHER, PATH_REPLACER) + "$");
       }
-      // lookup callback
-      if (typeof callback == 'string') {
-        callback = app[callback];
-      }
+      // lookup callbacks
+			$.each(callback,function(i,cb){
+	      if (typeof cb == 'string') {
+	        callback[i] = app[cb];
+	      }
+			});
 
       add_route = function(with_verb) {
         var r = {verb: with_verb, path: path, callback: callback, param_names: param_names};
@@ -797,6 +801,58 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
     //
     around: function(callback) {
       this.arounds.push(callback);
+      return this;
+    },
+
+    // Adds a finally function to the application. finally functions are executed
+		// at the end of a chain of route callbacks, if they call next(). Unlike after,
+		// which is called as soon as the route is complete, finally is like a final next()
+		// for all routes, and is thus run asynchronously
+    //
+    // ### Example
+    //
+    // app.get('/chain',function(context,next){
+		// 		console.log('chain1');
+		//		next();
+		// },function(context,next){
+		// 		console.log('chain2');
+		//		next();
+		// });
+    // app.get('/link',function(context,next){
+		// 		console.log('link1');
+		//		next();
+		// },function(context,next){
+		// 		console.log('link2');
+		//		next();
+		// });
+		// app.finally(function(){
+		// 		console.log("Running finally")
+		// });
+		//
+		// If you go to '/chain', you will get the following messages:
+		//   chain1
+		//	 chain2
+		//   Running finally
+		//
+		//
+		// If you go to /link, you will get the following messages:
+		//   link1
+		//	 link2
+		//   Running finally
+		//
+		// It really comes to play when doing asynchronous:
+    // app.get('/chain',function(context,next){
+		//		$.get('/my/url',function(){
+		//	 		console.log('chain1');
+		//			next();
+		//		})
+		// },function(context,next){
+		// 		console.log('chain2');
+		//		next();
+		// });
+    //
+    finally: function(callback) {
+			this._finally = callback;
       return this;
     },
 
@@ -1055,10 +1111,13 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
         arounds = this.arounds.slice(0);
         befores = this.befores.slice(0);
         // set the callback args to the context + contents of the splat
-        callback_args = [context].concat(params.splat);
+				callback_args = [context];
+				if (params.splat) {
+					callback_args = callback_args.concat(params.splat);
+				}
         // wrap the route up with the before filters
         wrapped_route = function() {
-          var returned;
+          var returned, i, nextRoute;
           while (befores.length > 0) {
             before = befores.shift();
             // check the options
@@ -1069,7 +1128,23 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
           }
           app.last_route = route;
           context.trigger('event-context-before', {context: context});
-          returned = route.callback.apply(context, callback_args);
+					// run multiple callbacks
+					if (typeof(route.callback) === "function") {
+						route.callback = [route.callback];
+					}
+					if (route.callback && route.callback.length) {
+						i = -1;
+						nextRoute = function() {
+							i++;
+							if (route.callback[i]) {
+								returned = route.callback[i].apply(context,callback_args);
+							} else if (app._finally && typeof(app._finally === "function")) {
+								app._finally(context);
+							}
+						};
+						callback_args.push(nextRoute);
+						nextRoute();
+					}
           context.trigger('event-context-after', {context: context});
           return returned;
         };

--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -579,7 +579,7 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
       }
       // lookup callbacks
 			$.each(callback,function(i,cb){
-	      if (typeof cb == 'string') {
+	      if (typeof(cb) === 'string') {
 	        callback[i] = app[cb];
 	      }
 			});

--- a/test/application_spec.js
+++ b/test/application_spec.js
@@ -623,8 +623,10 @@ describe('Application', function() {
       });
 			it('passes to multiple chained callbacks',function(done) {
 				var cb1 = function(ctx,next) {
-					flag = 10;
-					next();
+		      $.get('fixtures/partial', function() {
+						flag = 10;
+						next();
+					});
 				}, cb2 = function(ctx,next) {
 					expect(flag).to.eql(10);
 					next();
@@ -635,11 +637,15 @@ describe('Application', function() {
 			});
 			it('runs finally',function(done) {
 				var cb1 = function(ctx,next) {
-					flag1 = 10;
-					next();
+					$.get('fixtures/partial',function(){
+						flag1 = 10;
+						next();
+					});
 				}, cb2 = function(ctx,next) {
-					flag2 = 20;
-					next();
+					$.get('fixtures/partial.html',function(){
+						flag2 = 20;
+						next();
+					});
 				}, flag1 = 12, flag2 = 22;
 				app.get('#/chain',cb1,cb2);
 				app.finally(function() {

--- a/test/application_spec.js
+++ b/test/application_spec.js
@@ -112,7 +112,8 @@ describe('Application', function() {
         var route = app.routes['get'][1];
         expect(route.path).to.be.a(RegExp);
         expect(route.verb).to.eql('get');
-        expect(route.callback).to.be.a(Function);
+        expect(route.callback).to.be.a(Array);
+        expect(route.callback[0]).to.be.a(Function);
       });
       
       it('allows shortcuts for defining routes', function() {
@@ -123,7 +124,8 @@ describe('Application', function() {
         var route = app.routes['get'][1];
         expect(route.path).to.be.a(RegExp);
         expect(route.verb).to.eql('get');
-        expect(route.callback).to.be.a(Function);
+        expect(route.callback).to.be.a(Array);
+        expect(route.callback[0]).to.be.a(Function);
       });
       
       it('appends late and short route', function() {
@@ -134,7 +136,8 @@ describe('Application', function() {
         var route = app.routes['get'][1];
         expect(route.path).to.be.a(RegExp);
         expect(route.verb).to.eql('get');
-        expect(route.callback).to.be.a(Function);
+        expect(route.callback).to.be.a(Array);
+        expect(route.callback[0]).to.be.a(Function);
         expect(route.path.toString()).to.eql(new RegExp("#/$").toString());
       });
       
@@ -142,7 +145,7 @@ describe('Application', function() {
         app.mycallback = function() { this.redirect('#/'); };
         app.post('#/post', 'mycallback');
         
-        expect(app.routes['post'][0].callback).to.eql(app.mycallback);
+        expect(app.routes['post'][0].callback[0]).to.eql(app.mycallback);
       });
       
       it('adds an "any" route to every route verb', function() {
@@ -185,7 +188,7 @@ describe('Application', function() {
       it('look up callbacks as strings', function() {
         var route = app.routes['get'].pop();
         expect(route.path.toString()).to.eql(new RegExp("#/string$").toString());
-        expect(route.callback).to.eql(context.empty_callback);
+        expect(route.callback[0]).to.eql(context.empty_callback);
       });
     });
     
@@ -490,7 +493,8 @@ describe('Application', function() {
         var route = app.lookupRoute('post', '/blah');
         expect(route).to.be.an(Object);
         expect(route.verb).to.eql('post');
-        expect(route.callback).to.be.a(Function);
+        expect(route.callback).to.be.a(Array);
+        expect(route.callback[0]).to.be.a(Function);
       });
       
       it('finds a route by verb and partial route', function() {
@@ -500,7 +504,8 @@ describe('Application', function() {
         var route = app.lookupRoute('get','/blah/mess');
         expect(route).to.be.an(Object);
         expect(route.verb).to.eql('get');
-        expect(route.callback).to.be.a(Function);
+        expect(route.callback).to.be.a(Array);
+        expect(route.callback[0]).to.be.a(Function);
       });
       
       it('ignores any hash query string when looking up a route', function() {
@@ -510,7 +515,8 @@ describe('Application', function() {
         var route = app.lookupRoute('get', '#/boo?ohdontmindeme');
         expect(route).to.be.an(Object);
         expect(route.verb).to.eql('get');
-        expect(route.callback).to.be.a(Function);
+        expect(route.callback).to.be.a(Array);
+        expect(route.callback[0]).to.be.a(Function);
       });
     });
     
@@ -615,6 +621,34 @@ describe('Application', function() {
           }).to.throwException(/404/);
         }, done);        
       });
+			it('passes to multiple chained callbacks',function(done) {
+				var cb1 = function(ctx,next) {
+					flag = 10;
+					next();
+				}, cb2 = function(ctx,next) {
+					expect(flag).to.eql(10);
+					next();
+					done();
+				}, flag = 12;
+				app.get('#/chain',cb1,cb2);
+				app.runRoute('get','#/chain');
+			});
+			it('runs finally',function(done) {
+				var cb1 = function(ctx,next) {
+					flag1 = 10;
+					next();
+				}, cb2 = function(ctx,next) {
+					flag2 = 20;
+					next();
+				}, flag1 = 12, flag2 = 22;
+				app.get('#/chain',cb1,cb2);
+				app.finally(function() {
+					expect(flag1).to.eql(10);
+					expect(flag2).to.eql(20);
+					done();
+				});
+				app.runRoute('get','#/chain');
+			});
     });
     
     describe('#before()', function() {

--- a/test/application_spec.js
+++ b/test/application_spec.js
@@ -273,6 +273,9 @@ describe('Application', function() {
           this.form_params = {};        
         });
       });
+			afterEach(function(){
+				app.unload();
+			});
       
       it('sets the location to the start url', function(done) {
         app.get('#/', function() {

--- a/test/location_proxy_spec.js
+++ b/test/location_proxy_spec.js
@@ -4,6 +4,7 @@ describe('DefaultLocationProxy', function() {
       has_history = window.history && history.pushState;
   
   beforeEach(function() {
+		window.location.hash = '';
     app = new Sammy.Application(function() {
       this.element_selector = '#main';
       this.get('#/', function() {});


### PR DESCRIPTION
Added support for asynchronous chaining of multiple callbacks for a route, without breaking backward compatibility of single route. 

Last argument to every callback is always next, whether it has a single 'context' argument, or multiple unnamed splat arguments.

Added async-supporting finally() function to be called after last next() in chaining route.

Added 1 test for chaining, and 1 for finally.

Updated tests to reflect that route.callback is now an array of function, rather than a single function.

See https://github.com/quirkey/sammy/issues/168
