### PR TITLE
Fix #174 - better "target" checking

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -217,7 +217,7 @@
 
 
   // Return whether the event targets this window.
-  function targetIsThisWindow(event) {
+  Sammy.targetIsThisWindow = function targetIsThisWindow(event) {
     var targetWindow = $(event.target).attr('target');
     if ( targetWindow === '_blank' ) { return false; }
     if ( targetWindow == null || targetWindow === window.name || targetWindow === '_self' ) { return true; }
@@ -293,7 +293,7 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
           var full_path = lp.fullPath(this);
           if (this.hostname == window.location.hostname &&
               app.lookupRoute('get', full_path) &&
-              targetIsThisWindow(e)) {
+              Sammy.targetIsThisWindow(e)) {
             e.preventDefault();
             proxy.setLocation(full_path);
             return false;
@@ -976,7 +976,7 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
 
       // bind to submit to capture post/put/delete routes
       this.bind('submit', function(e) {
-        if ( !targetIsThisWindow(e) ) { return true; }
+        if ( !Sammy.targetIsThisWindow(e) ) { return true; }
         var returned = app._checkFormSubmission($(e.target).closest('form'));
         return (returned === false) ? e.preventDefault() : false;
       });

--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -215,6 +215,17 @@
     }
   });
 
+
+  // Return whether the event targets this window.
+  function targetIsThisWindow(event) {
+    var targetWindow = $(event.target).attr('target');
+    if ( targetWindow === '_blank' ) { return false; }
+    if ( targetWindow == null || targetWindow === window.name || targetWindow === '_self' ) { return true; }
+    if ( targetWindow === 'top' && window === window.top ) { return true; }
+    return false;
+  }
+
+
   // The DefaultLocationProxy is the default location proxy for all Sammy applications.
   // A location proxy is a prototype that conforms to a simple interface. The purpose
   // of a location proxy is to notify the Sammy.Application its bound to when the location
@@ -282,7 +293,7 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
           var full_path = lp.fullPath(this);
           if (this.hostname == window.location.hostname &&
               app.lookupRoute('get', full_path) &&
-              this.target !== '_blank') {
+              targetIsThisWindow(e)) {
             e.preventDefault();
             proxy.setLocation(full_path);
             return false;
@@ -965,6 +976,7 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
 
       // bind to submit to capture post/put/delete routes
       this.bind('submit', function(e) {
+        if ( !targetIsThisWindow(e) ) { return true; }
         var returned = app._checkFormSubmission($(e.target).closest('form'));
         return (returned === false) ? e.preventDefault() : false;
       });

--- a/test/application_spec.js
+++ b/test/application_spec.js
@@ -290,8 +290,20 @@ describe('Application', function() {
           app.unload();
           done();
         };
-      
+
         app.run('#/');
+      });
+
+      it('ignores links that target other windows', function() {
+        var captured = false;
+        app.get('#/', function() {});
+        app.get('#/some/route', function() { captured = true; });
+
+        $('#main').append('<a href="#/some/route" target="another-window">Open in new window</a>');
+        app.run('#/');
+        $('#main a').click();
+
+        expect(captured).to.eql(false);
       });
       
       it('binds events to all forms', function(done) {
@@ -313,7 +325,20 @@ describe('Application', function() {
         );
         
         app.run('#/');
-        $('#main form').submit();        
+        $('#main form').submit();
+      });
+
+      it('ignores forms that target other windows', function() {
+        var captured = false;
+        app.get('#/', function() {});
+        app.get('#/a/route', function() { captured = true; });
+
+        $('#main').append('<form action="#/a/route" method="get" target="foo">' +
+          '<input type="submit" /></form>');
+        app.run('#/');
+        $('#main form').submit();
+
+        expect(captured).to.eql(false);
       });
       
       it('binds events to all future forms', function(done) {


### PR DESCRIPTION
Use a more sophisticated check for `target` on `a.click` and `form.submit` events.
