### PR TITLE
Changed $.live() to $.delegate()

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -286,8 +286,8 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
           app.trigger('location-changed');
         });
         // bind to link clicks that have routes
-        $('a').live('click.history-' + this.app.eventNamespace(), function(e) {
-          if (e.isDefaultPrevented() || e.metaKey || e.ctrlKey) {
+        $(document).delegate('a', 'click.history-' + this.app.eventNamespace(), function (e) {
+            if (e.isDefaultPrevented() || e.metaKey || e.ctrlKey) {
             return;
           }
           var full_path = lp.fullPath(this);


### PR DESCRIPTION
JQuery 1.9.0 removed $.live(), which Sammy still used at one point. Switched to $.delegate() per http://api.jquery.com/live/, which should be good for JQuery 1.4.3+ (haven't tested all those).
