### PR TITLE
Get hostname in a cross-browser compatible way

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -290,8 +290,19 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
             if (e.isDefaultPrevented() || e.metaKey || e.ctrlKey) {
             return;
           }
-          var full_path = lp.fullPath(this);
-          if (this.hostname == window.location.hostname &&
+            var full_path = lp.fullPath(this),
+                // Get anchor's host name in a cross browser compatible way.
+                // IE looses hostname property when setting href in JS 
+                // with a relative URL, e.g. a.setAttribute('href',"/whatever").
+                // Circumvent this problem by creating a new link with given URL and 
+                // querying that for a hostname. 
+                hostname = this.hostname ? this.hostname : function (a) {
+                    var l = document.createElement("a");
+                    l.href = a.href;
+                    return l.hostname;
+                }(this);
+
+          if (hostname == window.location.hostname &&
               app.lookupRoute('get', full_path) &&
               Sammy.targetIsThisWindow(e)) {
             e.preventDefault();

--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -287,20 +287,20 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
         });
         // bind to link clicks that have routes
         $(document).delegate('a', 'click.history-' + this.app.eventNamespace(), function (e) {
-            if (e.isDefaultPrevented() || e.metaKey || e.ctrlKey) {
+          if (e.isDefaultPrevented() || e.metaKey || e.ctrlKey) {
             return;
           }
-            var full_path = lp.fullPath(this),
-                // Get anchor's host name in a cross browser compatible way.
-                // IE looses hostname property when setting href in JS 
-                // with a relative URL, e.g. a.setAttribute('href',"/whatever").
-                // Circumvent this problem by creating a new link with given URL and 
-                // querying that for a hostname. 
-                hostname = this.hostname ? this.hostname : function (a) {
-                    var l = document.createElement("a");
-                    l.href = a.href;
-                    return l.hostname;
-                }(this);
+          var full_path = lp.fullPath(this),
+            // Get anchor's host name in a cross browser compatible way.
+            // IE looses hostname property when setting href in JS 
+            // with a relative URL, e.g. a.setAttribute('href',"/whatever").
+            // Circumvent this problem by creating a new link with given URL and 
+            // querying that for a hostname. 
+            hostname = this.hostname ? this.hostname : function (a) {
+              var l = document.createElement("a");
+              l.href = a.href;
+              return l.hostname;
+            }(this);
 
           if (hostname == window.location.hostname &&
               app.lookupRoute('get', full_path) &&

--- a/test/location_proxy_spec.js
+++ b/test/location_proxy_spec.js
@@ -133,9 +133,34 @@ describe('DefaultLocationProxy', function() {
       var originalLocation = proxy.getLocation();
       $('#push').click();
     });
+
+    it('empty link hostname does not break push state links', function (done) {
+      var link = $('<a href="/push">test</a>');
+
+      app.bind('location-changed', function () {
+        expect(proxy.getLocation()).to.eql('/push');
+        app.unload();
+        done();
+      });
+
+      $('#main').append(link);
+
+      // Browsers do not allow clearing hostname by JS without affecting 
+      // the href property. Therefore this test is meaningful on IE only, 
+      // as the following line clears the hostname property on IE.
+      link.get(0).setAttribute('href', '/push');
+      
+      app.get('/push', function () { });
+
+      app.run('#/');
+      expect(app.isRunning()).to.be(true);
+
+      link.click();
+    });
   } else {
     it('pushes and pops state if History is available');
     it('binds to push state links');
+    it('empty link hostname does not break push state links');
   }
 
   it('handles arbitrary non-specific locations', function(done) {


### PR DESCRIPTION
Internet Explorer looses A.hostname property when href is set
dynamically with .setAttribute('href', '/whatever'). This is a problem
with client side templating engines like knockout.js. E.g. this link
created with templating would not work correctly in sammy.js, as it does
not have hostname.

```
<a data-bind="text: text, attr: { href: url}"></a>
```

The issue is fixed by checking hostname, and if it is missing, create a
new link and query the hostname from that link.
