### PR TITLE
Fix AMD issues.

### DIFF
--- a/lib/plugins/sammy.haml.js
+++ b/lib/plugins/sammy.haml.js
@@ -4,7 +4,7 @@
   } else {
     (window.Sammy = window.Sammy || {}).Haml = factory(window.jQuery, window.Sammy, window.Haml);
   }
-}(function ($, Sammy, Haml) {
+}(function ($, Sammy) {
 
   // `Sammy.Haml` provides a quick way of using haml style templates in your app.
   // The plugin wraps haml-js library created by Tim Caswell at

--- a/lib/plugins/sammy.haml.js
+++ b/lib/plugins/sammy.haml.js
@@ -2,7 +2,7 @@
   if (typeof define === 'function' && define.amd) {
     define(['jquery', 'sammy', 'haml'], factory);
   } else {
-    (window.Sammy = window.Sammy || {}).Haml = factory(window.jQuery, window.Sammy, window.Haml);
+    (window.Sammy = window.Sammy || {}).Haml = factory(window.jQuery, window.Sammy);
   }
 }(function ($, Sammy) {
 

--- a/lib/plugins/sammy.handlebars.js
+++ b/lib/plugins/sammy.handlebars.js
@@ -2,9 +2,9 @@
   if (typeof define === 'function' && define.amd) {
     define(['jquery', 'sammy', 'handlebars'], factory);
   } else {
-    (window.Sammy = window.Sammy || {}).Handlebars = factory(window.jQuery, window.Sammy, window.Handlebars);
+    (window.Sammy = window.Sammy || {}).Handlebars = factory(window.jQuery, window.Sammy);
   }
-}(function ($, Sammy, Handlebars) {
+}(function ($, Sammy) {
 
     // <tt>Sammy.Handlebars</tt> provides a quick way of using Handlebars templates in your app.
     //

--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -3,17 +3,16 @@
 
 // Sammy.js / http://sammyjs.org
 
-(function($, window) {
-  (function(factory){
-    // Support module loading scenarios
-    if (typeof define === 'function' && define.amd){
-      // AMD Anonymous Module
-      define(['jquery'], factory);
-    } else {
-      // No module loader (plain <script> tag) - put directly in global namespace
-      $.sammy = window.Sammy = factory($);
-    }
-  })(function($){
+(function(factory){
+  // Support module loading scenarios
+  if (typeof define === 'function' && define.amd){
+    // AMD Anonymous Module
+    define(['jquery'], factory);
+  } else {
+    // No module loader (plain <script> tag) - put directly in global namespace
+    $.sammy = window.Sammy = factory($);
+  }
+})(function($){
 
   var Sammy,
       PATH_REPLACER = "([^\/]+)",
@@ -2117,4 +2116,3 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
 
   return Sammy;
 });
-})(jQuery, window);

--- a/test/application_spec.js
+++ b/test/application_spec.js
@@ -1,4 +1,10 @@
 describe('Application', function() {
+  describe('AMD module', function() {
+    it('should register as an AMD module', function() {
+      expect(amdDefined).to.eql(Sammy);
+    });
+  });
+
   describe('apps', function() {
     it('returns a new application if no arguments are passed', function() {
       var app = Sammy();

--- a/test/index.html
+++ b/test/index.html
@@ -13,6 +13,32 @@
     <script src="../vendor/mocha/mocha.js"></script>
     <script src="../vendor/mocha/helpers.js"></script>
     <script>
+      /**
+       * Set up a mock AMD define function for testing AMD registration.
+       */
+      function define(dependencies, callback) {
+        // These libs behave like good AMD citizens, treat them that way.
+        var moduleMap = {
+          'jquery':     window.jQuery,
+          'sammy':      window.Sammy,
+          'mustache':   window.Mustache,
+          'ejs':        window.EJS
+        },
+        modules = dependencies.map(function (modName) {
+          return moduleMap[modName];
+        })
+
+        // Sammy is being defined
+        if (dependencies.length == 1) {
+          amdDefined = callback(jQuery);
+          window.Sammy = jQuery.sammy = amdDefined;
+        } else
+          callback.apply(undefined, modules);
+      }
+      define.amd = {
+        jQuery: true
+      };
+
       mocha.setup({
         ui: 'bdd',
         ignoreLeaks: true

--- a/test/index.html
+++ b/test/index.html
@@ -26,23 +26,25 @@
         },
         modules = dependencies.map(function (modName) {
           return moduleMap[modName];
-        })
+        });
 
         // Sammy is being defined
         if (dependencies.length == 1) {
-          amdDefined = callback(jQuery);
-          window.Sammy = jQuery.sammy = amdDefined;
-        } else
+          // this global var is the tested object in the AMD test
+          window.amdDefined = callback(jQuery);
+          window.Sammy = jQuery.sammy = window.amdDefined;
+        } else {
           callback.apply(undefined, modules);
+        }
       }
       define.amd = {
         jQuery: true
       };
 
-      mocha.setup({
+      window.mocha.setup({
         ui: 'bdd',
         ignoreLeaks: true
-      })
+      });
     </script>
 
     <script type="text/javascript" src="../vendor/templating/mustache.js"></script>


### PR DESCRIPTION
Issues solved:
- Add a unit test for AMD loading.
- Remove the first (unnecessary) IIFE which causes a loading problem when used in a full AMD environment. (because the global jQuery is not defined yet)
- Plugins that depend on libraries that are not AMD modules (haml and handlebars) should use global objects.
