### PR TITLE
Allow more liberal matching of template names

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -1960,7 +1960,7 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
       if (_isFunction(engine)) { return engine; }
       // lookup engine name by path extension
       engine = (engine || context.app.template_engine).toString();
-      if ((engine_match = engine.match(/\.([^\.\?\#]+)$/))) {
+      if ((engine_match = engine.match(/\.([^\.\?\#]+)(\?|$)/))) {
         engine = engine_match[1];
       }
       // set the engine to the default template engine if no match is found

--- a/test/event_context_spec.js
+++ b/test/event_context_spec.js
@@ -95,6 +95,15 @@ describe('EventContext', function() {
       });
     });
 
+    it('runs through template() if Sammy.Template _is_ present _and_ GET parameters appended', function(done) {
+      app.use(Sammy.Template);
+      context = new app.context_prototype(app);
+      context.partial('./fixtures/../fixtures/partial.template?var1=09&var2=abc', {name: 'TEMPLATE!', class_name: 'test_template'}).then(function(data) {
+        expect(data).to.eql('<div class="test_template">TEMPLATE!</div>');
+        done();
+      });
+    });
+
     it('replaces the default app element if no callback is passed', function(done) {
       listenToChanged(app, {
         setup: function() {


### PR DESCRIPTION
This small change allows the template name to match when GET parameters are tacked on the end.

i.e. main.template?version=0.10 is still a .template file
