### PR TITLE
Nested 'then' not working properly. Fixed

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -1551,9 +1551,11 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
       }
       var context = this;
       if (this.waiting) {
-        this.callbacks.push(callback);
+     	  this.callbacks.splice(this.inAThen,0,callback);
+    	  this.inAThen++;
       } else {
         this.wait();
+        this.inAThen = 0;
         window.setTimeout(function() {
           var returned = callback.apply(context, [context.content, context.previous_content]);
           if (returned !== false) {


### PR DESCRIPTION
In previous version nested then didn't work at expected:

``` javascript
context.load("templates/home.template"
            ).then(function(){
                context.log("1");
                this.load("templates/home.template"
                ).then(function(){
                    context.log("2");
                    this.load("templates/home.template"
                    ).then(function(){
                        context.log("3");
                        this.load("templates/home.template"
                        ).then(function(){
                            context.log("3a");
                        }).then(function(){
                            context.log("3b");
                        });
                    });
                }).then(function(){
                    context.log("4");
                });
            }).then(function(){
                context.log("5");
            }).then(function(){
                context.log("6");
                this.load("templates/home.template"
                ).then(function(){
                    context.log("7");
                    this.load("templates/home.template"
                    ).then(function(){
                        context.log("8");
                    });
                }).then(function(){
                    context.log("9");
                });             
            });
```

returns: 

[Fri Jun 07 2013 16:47:28 GMT+0200 (CEST)] 1 sammy.js:97
[Fri Jun 07 2013 16:47:28 GMT+0200 (CEST)] 5 sammy.js:97
[Fri Jun 07 2013 16:47:28 GMT+0200 (CEST)] 6 sammy.js:97
[Fri Jun 07 2013 16:47:28 GMT+0200 (CEST)] 2 sammy.js:97
[Fri Jun 07 2013 16:47:28 GMT+0200 (CEST)] 4 sammy.js:97
[Fri Jun 07 2013 16:47:28 GMT+0200 (CEST)] 7 sammy.js:97
[Fri Jun 07 2013 16:47:28 GMT+0200 (CEST)] 9 sammy.js:97
[Fri Jun 07 2013 16:47:39 GMT+0200 (CEST)] 3 sammy.js:97
[Fri Jun 07 2013 16:47:39 GMT+0200 (CEST)] 8 sammy.js:97
[Fri Jun 07 2013 16:47:39 GMT+0200 (CEST)] 3a sammy.js:97
[Fri Jun 07 2013 16:47:39 GMT+0200 (CEST)] 3b sammy.js:97

With the change it outputs what we expect:

[Fri Jun 07 2013 16:48:41 GMT+0200 (CEST)] 1 sammy.js:97
[Fri Jun 07 2013 16:48:41 GMT+0200 (CEST)] 2 sammy.js:97
[Fri Jun 07 2013 16:48:41 GMT+0200 (CEST)] 3 sammy.js:97
[Fri Jun 07 2013 16:48:41 GMT+0200 (CEST)] 3a sammy.js:97
[Fri Jun 07 2013 16:48:41 GMT+0200 (CEST)] 3b sammy.js:97
[Fri Jun 07 2013 16:48:41 GMT+0200 (CEST)] 4 sammy.js:97
[Fri Jun 07 2013 16:48:41 GMT+0200 (CEST)] 5 sammy.js:97
[Fri Jun 07 2013 16:48:41 GMT+0200 (CEST)] 6 sammy.js:97
[Fri Jun 07 2013 16:48:41 GMT+0200 (CEST)] 7 sammy.js:97
[Fri Jun 07 2013 16:48:41 GMT+0200 (CEST)] 8 sammy.js:97
[Fri Jun 07 2013 16:48:41 GMT+0200 (CEST)] 9 sammy.js:97
