### PR TITLE
Add support for Handlebars 1.1.0-alpha.01

### DIFF
--- a/lib/plugins/sammy.handlebars.js
+++ b/lib/plugins/sammy.handlebars.js
@@ -4,7 +4,9 @@
   } else {
     (window.Sammy = window.Sammy || {}).Handlebars = factory(window.jQuery, window.Sammy);
   }
-}(function ($, Sammy) {
+}(function ($, Sammy, Handlebars) {
+    // version 1.0.0 has no support for AMD but upwards does, this way we support both.
+    Handlebars = Handlebars || window.Handlebars;
 
     // <tt>Sammy.Handlebars</tt> provides a quick way of using Handlebars templates in your app.
     //


### PR DESCRIPTION
This still works without AMD and for Handlebars 1.0.0 final which
has no support for AMD. Also see: https://github.com/wycats/handlebars.js/pull/537
