### PR TITLE
contextMatchesOptions: Added additional documentation for specifying verb *and* path.

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -1225,6 +1225,10 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
     //     // match all except a path
     //     app.contextMatchesOptions(context, {except: {path:'#/otherpath'}}); //=> true
     //     app.contextMatchesOptions(context, {except: {path:'#/mypath'}}); //=> false
+    //     // match all except a verb and a path
+    //     app.contextMatchesOptions(context, {except: {path:'#/otherpath', verb:'post'}}); //=> true
+    //     app.contextMatchesOptions(context, {except: {path:'#/mypath', verb:'post'}}); //=> true
+    //     app.contextMatchesOptions(context, {except: {path:'#/mypath', verb:'get'}}); //=> false
     //     // match multiple paths
     //     app.contextMatchesOptions(context, {path: ['#/mypath', '#/otherpath']}); //=> true
     //     app.contextMatchesOptions(context, {path: ['#/otherpath', '#/thirdpath']}); //=> false
@@ -1234,6 +1238,9 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
     //     // match all except multiple paths
     //     app.contextMatchesOptions(context, {except: {path: ['#/mypath', '#/otherpath']}}); //=> false
     //     app.contextMatchesOptions(context, {except: {path: ['#/otherpath', '#/thirdpath']}}); //=> true
+    //     // match all except multiple paths and verbs
+    //     app.contextMatchesOptions(context, {except: {path: ['#/mypath', '#/otherpath'], verb: ['get', 'get']}}); //=> false
+    //     app.contextMatchesOptions(context, {except: {path: ['#/otherpath', '#/thirdpath'], verb: ['get', 'get']}}); //=> true
     //
     contextMatchesOptions: function(context, match_options, positive) {
       var options = match_options;


### PR DESCRIPTION
Took me some time to figure out how this works (actually I had to look in the tests), so I think it should be in the docs.
