### PR TITLE
Added support for the new google analytics.js

### DIFF
--- a/lib/plugins/sammy.googleanalytics.js
+++ b/lib/plugins/sammy.googleanalytics.js
@@ -14,12 +14,16 @@
   //
   // +tracker+:: the Google Analytics pageTracker object.  Defaults to
   // the default object defined by the GA snippet, or pass your own if you
-  // have a custom install
+  // have a custom install. If using analytics.js pass a string with the
+  // name of your tracker.
   //
   // ### Example
   //
-  // Install Google Analytics to your site as you normally would. Be sure that
-  // the 'pageTracker' global variable exists.
+  // Install Google Analytics to your site as you normally would. 
+  // 
+  // If using ga.js be sure that the 'pageTracker' global variable exists.
+  // If using analytics.js there is nothing to do (but you probably want 
+  // to remove the ga('send','pageview') line)
   //
   // Then, simply add the plugin to your Sammy App and it will automatically
   // track all of your routes in Google Analytics.
@@ -44,7 +48,13 @@
   //
   Sammy.GoogleAnalytics = function(app, tracker) {
     var _tracker = tracker || window.pageTracker,
+      trackerName = "send",
       shouldTrack = true;
+
+    if (typeof tracker == 'string' || tracker instanceof String){
+      trackerName = tracker + ".send";
+      delete _tracker;
+    }
 
     function disableTracking() {
       shouldTrack = false;
@@ -59,6 +69,10 @@
         _tracker._trackPageview(path);
       } else if (typeof _gaq != 'undefined') {
         _gaq.push(['_trackPageview', path]);
+      } else if (typeof ga == 'function') {
+        ga(trackerName,'pageview',{
+          'page': path
+        });
       }
     }
 
@@ -70,7 +84,7 @@
       },
       // send a page view to the tracker with `path`
       track: function(path) {
-        if((typeof _tracker != 'undefined' || typeof _gaq != "undefined") && shouldTrack) {
+        if((typeof _tracker != 'undefined' || typeof _gaq != "undefined" || typeof ga == 'function') && shouldTrack) {
           this.log('tracking google analytics', path);
           trackPageview(path);
         }

--- a/lib/plugins/sammy.googleanalytics.js
+++ b/lib/plugins/sammy.googleanalytics.js
@@ -48,11 +48,11 @@
   //
   Sammy.GoogleAnalytics = function(app, tracker) {
     var _tracker = tracker || window.pageTracker,
-      trackerName = "send",
+      trackerName = 'send',
       shouldTrack = true;
 
     if (typeof tracker == 'string' || tracker instanceof String){
-      trackerName = tracker + ".send";
+      trackerName = tracker + '.send';
       delete _tracker;
     }
 
@@ -70,7 +70,7 @@
       } else if (typeof _gaq != 'undefined') {
         _gaq.push(['_trackPageview', path]);
       } else if (typeof ga == 'function') {
-        ga(trackerName,'pageview',{
+        ga(trackerName, 'pageview', {
           'page': path
         });
       }
@@ -84,7 +84,7 @@
       },
       // send a page view to the tracker with `path`
       track: function(path) {
-        if((typeof _tracker != 'undefined' || typeof _gaq != "undefined" || typeof ga == 'function') && shouldTrack) {
+        if((typeof _tracker != 'undefined' || typeof _gaq != 'undefined' || typeof ga == 'function') && shouldTrack) {
           this.log('tracking google analytics', path);
           trackPageview(path);
         }

--- a/lib/plugins/sammy.googleanalytics.js
+++ b/lib/plugins/sammy.googleanalytics.js
@@ -53,7 +53,6 @@
 
     if (typeof tracker == 'string' || tracker instanceof String){
       trackerName = tracker + '.send';
-      delete _tracker;
     }
 
     function disableTracking() {
@@ -65,14 +64,12 @@
     }
 
     function trackPageview(path) {
-      if (typeof _tracker != 'undefined') {
-        _tracker._trackPageview(path);
+      if (typeof ga == 'function') {
+        ga(trackerName, 'pageview', { 'page': path });
       } else if (typeof _gaq != 'undefined') {
         _gaq.push(['_trackPageview', path]);
-      } else if (typeof ga == 'function') {
-        ga(trackerName, 'pageview', {
-          'page': path
-        });
+      } else if (typeof _tracker != 'undefined') {
+        _tracker._trackPageview(path);
       }
     }
 


### PR DESCRIPTION
Fixes #208 
Preserves backwards compatibility and support for custom trackers.
