### PR TITLE
change sequence of assignment in app#route

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -291,10 +291,10 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
           }
           var full_path = lp.fullPath(this),
             // Get anchor's host name in a cross browser compatible way.
-            // IE looses hostname property when setting href in JS 
+            // IE looses hostname property when setting href in JS
             // with a relative URL, e.g. a.setAttribute('href',"/whatever").
-            // Circumvent this problem by creating a new link with given URL and 
-            // querying that for a hostname. 
+            // Circumvent this problem by creating a new link with given URL and
+            // querying that for a hostname.
             hostname = this.hostname ? this.hostname : function (a) {
               var l = document.createElement("a");
               l.href = a.href;
@@ -578,8 +578,8 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
       // if the method signature is just (path, callback)
       // assume the verb is 'any'
       if (callback.length === 0 && _isFunction(path)) {
-        path = verb;
         callback = [path];
+        path = verb;
         verb = 'any';
       }
 


### PR DESCRIPTION
if no `verb` argument is applied in `app.route(verb, path)`, the code snippet below mistakes in assignment  sequence:

```
// if the method signature is just (path, callback)
// assume the verb is 'any'
  if (callback.length === 0 && _isFunction(path)) {
    path = verb;
    callback = [path];
    verb = 'any';
  }
```
