### PR TITLE
Allow using jQuery noConflict mode

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -10,7 +10,7 @@
     define(['jquery'], factory);
   } else {
     // No module loader (plain <script> tag) - put directly in global namespace
-    $.sammy = window.Sammy = factory($);
+    jQuery.sammy = window.Sammy = factory(jQuery);
   }
 })(function($){
 


### PR DESCRIPTION
In [noConflict mode](http://api.jquery.com/jQuery.noConflict/) `$` is not defined, you have to use `jQuery`instead
