### PR TITLE
Improve json detection

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -1637,7 +1637,7 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
         if (callback) { this.then(callback); }
         if (typeof location === 'string') {
           // it's a path
-          is_json      = (location.match(/\.json$/) || options.json);
+          is_json      = (location.match(/\.json(\?|$)/) || options.json);
           should_cache = is_json ? options.cache === true : options.cache !== false;
           context.next_engine = context.event_context.engineFor(location);
           delete options.cache;

--- a/test/render_context_spec.js
+++ b/test/render_context_spec.js
@@ -281,6 +281,21 @@ describe('RenderContext', function() {
     });
   });
 
+  it('detects json format when a query string is present', function(done) {
+    listenToChanged(app, {
+      setup: function() {
+        context.load('fixtures/partial.json?qs=1')
+          .render('fixtures/partial.template')
+          .replace('#main');
+      },
+      onChange: function() {
+        expect($('#main')).to.have.sameHTMLAs('<div id="main"><div class="original">json</div></div>');
+        app.unload();
+        done();
+      }
+    });
+  });
+
   it('appends then passes data to then', function(done) {
     $('#main').html('');
     context.load('fixtures/partial.html')


### PR DESCRIPTION
Before this change `this.load("/path/to/data.json?start=0")` would not be detected as JSON because of the presence of a query string -  `this.load("/path/to/data.json")` would be detected as JSON.

Of course it is possible to override the format using `options.json` but this little change would be a nice to have.
