### PR TITLE
Fix Issue #213

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -598,7 +598,7 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
           param_names.push(path_match[1]);
         }
         // replace with the path replacement
-        path = new RegExp(path.replace(PATH_NAME_MATCHER, PATH_REPLACER) + "$");
+        path = new RegExp(path.replace(PATH_NAME_MATCHER, PATH_REPLACER) + "$", 'i');
       }
       // lookup callbacks
       $.each(callback,function(i,cb){


### PR DESCRIPTION
Pass ignore case symbol when creating new RegExp instance which is used to match a given path
