### PR TITLE
Fixed issue #221 when the limit is reached when initializing Sammy JS

### DIFF
--- a/lib/plugins/sammy.storage.js
+++ b/lib/plugins/sammy.storage.js
@@ -340,7 +340,17 @@
   };
   $.extend(Sammy.Store.LocalStorage.prototype, {
     isAvailable: function() {
-      return ('localStorage' in window) && (window.location.protocol != 'file:');
+      if (('localStorage' in window) && (window.location.protocol != 'file:')) {
+        try {
+          window.localStorage.setItem('sammyjs_test', 'This is just a test if I can set something in the local storage. There is nothing to see here, please continue ...');
+          window.localStorage.removeItem('sammyjs_test');
+          return true;
+        } catch (ex) {
+          // Oh noes, localStorage is available but I can't set anything ... maybe the limit is reached?
+          return false;
+        }
+      }
+      return false;
     },
     exists: function(key) {
       return (this.get(key) != null);


### PR DESCRIPTION
Fixes #221, at least when no values can be set into the localStorage initially.
Maybe the same issue arises when the limit is reached later on, when using .set? This should be investigated further, but I do not know the sammy source code enough to add a fallback for this case.
