### PR TITLE
add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "sammyjs",
+  "version": "0.7.5",
+  "homepage": "http://sammyjs.org",
+  "authors": [
+    "Aaron Quint",
+    "Frank Prößdorf"
+  ],
+  "description": "Sammy is a tiny javascript framework built on top of jQuery, It's RESTful Evented Javascript",
+  "main": "/lib/sammy.js",
+  "keywords": [
+    "mvc",
+    "REST",
+    "framework",
+    "routing"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "test",
+    "vendor"
+  ],
+  "dependencies": {
+    "jquery": ">=1.4.1"
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "sammyjs",
+  "name": "sammy",
   "version": "0.7.5",
   "homepage": "http://sammyjs.org",
   "authors": [


### PR DESCRIPTION
fixes #225

Looks like the package is already registered on bower, but not having a bower.json makes bower install too much stuff. (also not having a bower.json in your source makes people think that the package isnt on bower)

This bower.json will ignore some stuff that you wouldnt need - the `test` and `vendor` dirs. 

I am not sure if you will need to create another tag in order for bower to notice this json - easy to test. 
