### PR TITLE
Added to EventContext.renderEach documentation

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -2027,6 +2027,13 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
     // Loads the template and interpolates the data for each item,
     // however does not actually place it in the DOM.
     //
+    // `name` is an optional parameter (if it is an array, it is used as `data`,
+    // and the third parameter used as `callback`, if set).
+    //
+    // If `data` is not provided, content from the previous step in the chain 
+    // (if it is an array) is used, and `name` is used as the key for each 
+    // element of the array (useful for referencing in template).
+    //
     // ### Example
     //
     //      // mytemplate.mustache <div class="name">{{name}}</div>
@@ -2034,6 +2041,10 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
     //      // sets the `content` to <div class="name">quirkey</div><div class="name">endor</div>
     //      renderEach('mytemplate.mustache', [{name: 'quirkey'}, {name: 'endor'}]).appendTo('ul');
     //      // appends the rendered content to $('ul')
+    //
+    //      // names.json: ['quirkey', 'endor']
+    //      this.load('names.json').renderEach('mytemplate.mustache', 'name').appendTo('ul');
+    //      // uses the template to render each item in the JSON array
     //
     renderEach: function(location, name, data, callback) {
       return new Sammy.RenderContext(this).renderEach(location, name, data, callback);

--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -2025,7 +2025,7 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
 
     // Create and return a `Sammy.RenderContext` calling `renderEach()` on it.
     // Loads the template and interpolates the data for each item,
-    // however does not actual place it in the DOM.
+    // however does not actually place it in the DOM.
     //
     // ### Example
     //


### PR DESCRIPTION
It took me quite a lot of experimentation and reading the sammy source code to understand how the different arguments worked, especially as the provided examples plainly ignore the `name` argument without explanation. I also explained that the data can come from the previous step in the chain (is that the right terminology for `previous_content`?), as it's used in the sample on the front page, but not explained.

I also fixed a typo.
