### PR TITLE
Capability to configure case-sensitivity

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -447,6 +447,12 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
     // for more information
     template_engine: null,
 
+    // The default for Sammy on string-based route definitions is to convert to a
+    // case-sensitive Regex, enabling this setting makes all string defined routes
+    // for this instance of Sammy.Application case-insensitive.
+    //Has no effect on regex routes.
+    routes_case_insensitive: false,
+
     // //=> Sammy.Application: body
     toString: function() {
       return 'Sammy.Application:' + this.element_selector;
@@ -601,7 +607,10 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
           param_names.push(path_match[1]);
         }
         // replace with the path replacement
-        path = new RegExp(path.replace(PATH_NAME_MATCHER, PATH_REPLACER) + "$");
+        // If routes are supposed to be case-insensitive, add the regex modifier.
+        path = this.routes_case_insensitive
+            ? new RegExp(path.replace(PATH_NAME_MATCHER, PATH_REPLACER) + "$", "i")
+            : new RegExp(path.replace(PATH_NAME_MATCHER, PATH_REPLACER) + "$");
       }
       // lookup callbacks
       $.each(callback,function(i,cb){


### PR DESCRIPTION
This change allows a user to opt-in to case-insensitivity for routes at
a Sammy.Application level. This feature is pivotal for inclusion in
ASP.NET WebForms and MVC platforms where URL casing is not enforced in general any IIS hosted application as well.

This is a more friendly form of a prior request #215 ( #213 ).
