### PR TITLE
Type check for object instead of string

### DIFF
--- a/lib/sammy.js
+++ b/lib/sammy.js
@@ -2092,11 +2092,11 @@ $.extend(Sammy.DefaultLocationProxy.prototype , {
       if (l > 1) {
         var i = 0, paths = [], pairs = [], params = {}, has_params = false;
         for (; i < l; i++) {
-          if (typeof args[i] == 'string') {
-            paths.push(args[i]);
-          } else {
+          if (typeof args[i] == 'object') {
             $.extend(params, args[i]);
             has_params = true;
+          } else {
+            paths.push(args[i]);
           }
         }
         to = paths.join('/');


### PR DESCRIPTION
When redirecting Sammyjs will not join an integer with a string. This
seems like odd behavior.
