### PR TITLE
Change Mustache to_html to render

### DIFF
--- a/lib/plugins/sammy.mustache.js
+++ b/lib/plugins/sammy.mustache.js
@@ -113,7 +113,7 @@
     var mustache = function(template, data, partials) {
       data     = $.extend({}, this, data);
       partials = $.extend({}, data.partials, partials);
-      return Mustache.to_html(template, data, partials);
+      return Mustache.render(template, data, partials);
     };
 
     // set the default method name/extension


### PR DESCRIPTION
Mustache new version don't find to_html anymore. I think they change the nemo of function to "render". I changed in my project and have success using the new version of Mustache.